### PR TITLE
Fix private IP regex in URL validation

### DIFF
--- a/packages/workrail/src/utils/storage-security.ts
+++ b/packages/workrail/src/utils/storage-security.ts
@@ -97,11 +97,11 @@ export function validateSecureUrl(url: string): void {
     
     // Prevent localhost and private IP access
     const hostname = parsed.hostname.toLowerCase();
-    if (hostname === 'localhost' || 
-        hostname === '127.0.0.1' || 
+    if (hostname === 'localhost' ||
+        hostname === '127.0.0.1' ||
         hostname.startsWith('192.168.') ||
         hostname.startsWith('10.') ||
-        hostname.startsWith('172.')) {
+        /^172\.(1[6-9]|2[0-9]|3[01])\./.test(hostname)) {
       throw new SecurityError(
         'Access to local/private networks not allowed',
         'url-validation'


### PR DESCRIPTION
## Summary
- fix logic that blocks private IPs in `validateSecureUrl`

## Testing
- `npx tsc -p packages/workrail/tsconfig.build.json --noEmit`
- `npx jest` *(fails: Test Suites: 39 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68863f00a5888330a37c2654a230315f