### PR TITLE
Fix workflow migration version comparison

### DIFF
--- a/packages/workrail/package.json
+++ b/packages/workrail/package.json
@@ -25,6 +25,7 @@
     "commander": "^14.0.0",
     "dotenv": "^17.2.0",
     "json-rpc-2.0": "^1.7.1",
+    "semver": "^7.7.2",
     "tsconfig-paths": "^4.2.0",
     "tslib": "^2.8.1",
     "zod": "^3.22.4"
@@ -39,6 +40,7 @@
   ],
   "devDependencies": {
     "@types/node": "^20.19.9",
+    "@types/semver": "^7.7.0",
     "typescript": "^5.8.3"
   }
 }

--- a/packages/workrail/src/cli/migrate-workflow.ts
+++ b/packages/workrail/src/cli/migrate-workflow.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import { Workflow } from '../types/mcp-types';
 import { validateWorkflow } from '../application/validation';
 import chalk from 'chalk';
+import semver from 'semver';
 
 export interface MigrationResult {
   success: boolean;
@@ -46,14 +47,14 @@ export function migrateWorkflow(workflow: any): MigrationResult {
   };
 
   // Check if migration is needed
-  if (result.originalVersion === result.targetVersion) {
+  if (semver.eq(result.originalVersion, result.targetVersion)) {
     result.success = true;
     result.warnings.push(`Workflow is already at version ${result.targetVersion}`);
     result.migratedWorkflow = workflow;
     return result;
   }
 
-  if (result.originalVersion > result.targetVersion) {
+  if (semver.gt(result.originalVersion, result.targetVersion)) {
     result.errors.push(`Cannot downgrade from version ${result.originalVersion} to ${result.targetVersion}`);
     return result;
   }

--- a/packages/workrail/tests/unit/migrate-workflow.test.ts
+++ b/packages/workrail/tests/unit/migrate-workflow.test.ts
@@ -137,10 +137,49 @@ describe('Workflow Migration', () => {
         name: 'Test',
         steps: []
       };
-      
+
       const result = migrateWorkflow(workflow);
       expect(result.success).toBe(false);
       expect(result.errors).toContain('Workflow must have an id');
+    });
+
+    it('performs upgrade from older version', () => {
+      const workflow = {
+        id: 'test',
+        name: 'Test',
+        description: 'Old workflow',
+        steps: [{ id: 'step1', title: 'Step 1', prompt: 'Do something' }]
+      };
+
+      const result = migrateWorkflow(workflow);
+      expect(result.success).toBe(true);
+      expect(result.migratedWorkflow?.version).toBe('0.1.0');
+    });
+
+    it('is no-op when workflow already at target version', () => {
+      const workflow = {
+        version: '0.1.0',
+        id: 'test',
+        name: 'Test',
+        steps: []
+      };
+
+      const result = migrateWorkflow(workflow);
+      expect(result.success).toBe(true);
+      expect(result.migratedWorkflow).toEqual(workflow);
+    });
+
+    it('detects downgrade from newer version', () => {
+      const workflow = {
+        version: '0.10.0',
+        id: 'test',
+        name: 'Test',
+        steps: []
+      };
+
+      const result = migrateWorkflow(workflow);
+      expect(result.success).toBe(false);
+      expect(result.errors).toContain('Cannot downgrade from version 0.10.0 to 0.1.0');
     });
   });
 


### PR DESCRIPTION
## Summary
- ensure workflow migration uses `semver` for version comparisons
- add `semver` dependency and corresponding types
- test upgrade, no-op and downgrade scenarios for workflow migration

## Testing
- `npx jest tests/unit/migrate-workflow.test.ts`
- `npm run --workspace=packages/workrail build`

------
https://chatgpt.com/codex/tasks/task_e_68864fe20d708330b191208fc6301ef8